### PR TITLE
fixing indentation of the detection field

### DIFF
--- a/analytics/gcp_perms_granted_over_service_acct.yml
+++ b/analytics/gcp_perms_granted_over_service_acct.yml
@@ -11,7 +11,7 @@ logsource:
   service: gcp.audit
 detection:
     methodnamestart:
-        gcp.audit.method_name|beginswith: google.iam.admin
+        gcp.audit.method_name|startswith: google.iam.admin
     methodsetpolicy:
         gcp.audit.method_name: SetIamPolicy
     selection_resource_type:

--- a/analytics/gcp_perms_granted_over_service_acct.yml
+++ b/analytics/gcp_perms_granted_over_service_acct.yml
@@ -9,7 +9,7 @@ references:
 logsource:
   product: gcp
   service: gcp.audit
-  detection:
+detection:
     methodnamestart:
         gcp.audit.method_name|beginswith: google.iam.admin
     methodsetpolicy:


### PR DESCRIPTION
Fixes # (issue)

## What Changed
1. Fixing indentation of the `detection` field. Sigma requires `detection` to be a top level field, not a field under `logsource`.
2. Also, Sigma uses a `startswith` operator, not `beginswith`. It's easy to spot by a human but it breaks automations.

## Limitations
None
